### PR TITLE
Add CI via Travis and code coverage via nyc and coveralls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-/node_modules
+node_modules/
+.nyc_output/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+sudo: false
+language: node_js
+node_js:
+  - 'node'
+  - '4'
+after_success: npm run coverage

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A linter for Dockerfiles to find bugs and encourage best practices",
   "main": "./lib/index.js",
   "scripts": {
-    "test": "mocha"
+    "test": "nyc mocha",
+    "coverage": "nyc report --reporter=text-lcov | coveralls"
   },
   "repository": {
     "type": "git",
@@ -22,8 +23,12 @@
   },
   "homepage": "https://github.com/replicatedhq/dockerfilelint#readme",
   "dependencies": {
-    "chai": "^3.5.0",
-    "mocha": "^2.4.5",
     "yargs": "^3.32.0"
+  },
+  "devDependencies": {
+    "chai": "^3.5.0",
+    "coveralls": "^2.11.6",
+    "mocha": "^2.4.5",
+    "nyc": "^5.6.0"
   }
 }


### PR DESCRIPTION
I mainly want to add this for selfish reasons in case I want to offer more contributions. :)

Will need to:

1. Sign in to coveralls.io and enable it for this repo
2. Add the Travis CI service on this repo and add a `COVERALLS_REPO_TOKEN` env var to your settings in https://travis-ci.org/replicatedhq/dockerfilelint
3. Enjoy watching PRs and pushes go green!

Might also be a good idea to add code linting (or at least an `.editorconfig` file). I like `standard` since it's a one-stop shop, but then you'd lose semicolons.

FYI, here's the initial `nyc` report with 17 passing tests:

```
----------------|----------|----------|----------|----------|----------------|
File            |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
----------------|----------|----------|----------|----------|----------------|
 lib/           |    95.76 |    93.59 |      100 |    95.76 |                |
  checks.js     |    97.37 |     96.3 |      100 |    97.37 |         83,149 |
  run_checks.js |    92.86 |     87.5 |      100 |    92.86 |       24,35,52 |
----------------|----------|----------|----------|----------|----------------|
All files       |    95.76 |    93.59 |      100 |    95.76 |                |
----------------|----------|----------|----------|----------|----------------|
```