### PR TITLE
Prettier CLI output

### DIFF
--- a/bin/dockerfilelint
+++ b/bin/dockerfilelint
@@ -4,6 +4,8 @@ var process = require('process');
 var fs = require('fs');
 var argv = require('yargs').argv;
 var dockerfilelint = require('../lib/index');
+var CliReporter = require('../lib/cli_reporter');
+var chalk = require('chalk');
 
 if (argv._.length === 0) {
   console.error('Usage: dockerfilelint <filename>');
@@ -19,10 +21,14 @@ try {
 
   var fileContent = fs.readFileSync(argv._[0], 'UTF-8');
   var result = dockerfilelint.run(fileContent);
-  console.log(result);
+  var reporter = new CliReporter();
+  reporter.addFile(argv._[0], fileContent, result);
+  var report = reporter.buildReport();
+  console.log(report.toString());
+  process.exit(report.totalIssues);
 } catch (e) {
   if (e.code === 'ENOENT') {
-    console.error('File not found');
+    console.error(chalk.red('File not found'));
     process.exit(1);
   }
 

--- a/lib/cli_reporter.js
+++ b/lib/cli_reporter.js
@@ -1,0 +1,106 @@
+'use strict';
+
+const notDeepStrictEqual = require('assert').notDeepStrictEqual;
+const chalk = require('chalk');
+const cliui = require('cliui');
+
+const DEFAULT_TOTAL_WIDTH = 110;
+const ISSUE_COL0_WIDTH = 5;
+const ISSUE_COL1_WIDTH = 14;
+const ISSUE_TITLE_WIDTH_MAX = 40;
+
+const PAD_TOP0_LEFT2 = [0, 0, 0, 2];
+const PAD_TOP1_LEFT0 = [1, 0, 0, 0];
+
+class CliReporter {
+  constructor (opts) {
+    opts = opts || { width: DEFAULT_TOTAL_WIDTH, wrap: true };
+    opts.width = parseInt(opts.width, 10) || DEFAULT_TOTAL_WIDTH;
+    this.ui = cliui(opts);
+    this.issueTitleWidth = Math.min(ISSUE_TITLE_WIDTH_MAX, parseInt((opts.width - ISSUE_COL0_WIDTH - ISSUE_COL1_WIDTH - 2) / 3.95, 10));
+    this.styles = {
+      'Deprecation': chalk.red,
+      'Possible Bug': chalk.yellow,
+      'Clarity': chalk.cyan,
+      'Optimization': chalk.cyan
+    };
+    this.fileReports = {};
+  }
+
+  // group file items by line for easy reporting
+  addFile (file, fileContent, items) {
+    let self = this;
+    if (!file) return self;
+    let fileReport = self.fileReports[file] || {
+      itemsByLine: {},
+      uniqueIssues: 0,
+      contentArray: (fileContent || '').replace('\r', '').split('\n')
+    };
+    let ibl = fileReport.itemsByLine;
+    [].concat(items).forEach((item) => {
+      if (ibl[String(item.line)]) {
+        try {
+          ibl[String(item.line)].forEach((lineItem) => {
+            notDeepStrictEqual(item, lineItem);
+          });
+          ibl[String(item.line)].push(item);
+          fileReport.uniqueIssues = fileReport.uniqueIssues + 1;
+        } catch (err) {
+          // ignore duplicate
+        }
+      } else {
+        ibl[String(item.line)] = [ item ];
+        fileReport.uniqueIssues = fileReport.uniqueIssues + 1;
+      }
+    });
+    self.fileReports[file] = fileReport;
+    return self;
+  }
+
+  // build a report object for data given via addFile
+  buildReport () {
+    let self = this;
+    let totalIssues = 0;
+    Object.keys(self.fileReports).forEach((file) => {
+      let fileReport = self.fileReports[file];
+      self.ui.div(
+        { text: 'File:   ' + file, padding: PAD_TOP1_LEFT0 }
+      );
+      let linesWithItems = Object.keys(fileReport.itemsByLine);
+      if (linesWithItems.length === 0) {
+        self.ui.div('Issues: ' + chalk.green('None found') + ' 👍');
+        return;
+      }
+      totalIssues += fileReport.uniqueIssues;
+      self.ui.div('Issues: ' + String(fileReport.uniqueIssues));
+
+      let itemNum = 1;
+      linesWithItems.forEach((lineNum) => {
+        self.ui.div({
+          text: 'Line ' + lineNum + ': ' + chalk.magenta(fileReport.contentArray[parseInt(lineNum, 10) - 1]),
+          padding: PAD_TOP1_LEFT0
+        });
+        self.ui.div(
+          { text: 'Issue', width: ISSUE_COL0_WIDTH },
+          { text: 'Category', padding: PAD_TOP0_LEFT2, width: ISSUE_COL1_WIDTH },
+          { text: 'Title', padding: PAD_TOP0_LEFT2, width: self.issueTitleWidth },
+          { text: 'Description', padding: PAD_TOP0_LEFT2 }
+        );
+        fileReport.itemsByLine[lineNum].forEach((item) => {
+          let cat = item.category;
+          let style = self.styles[cat] || self.styles['Clarity'];
+          self.ui.div(
+            { text: style(String(itemNum++)), width: ISSUE_COL0_WIDTH, align: 'right' },
+            { text: style.inverse(item.category), padding: PAD_TOP0_LEFT2, width: ISSUE_COL1_WIDTH },
+            { text: style(item.title), padding: PAD_TOP0_LEFT2, width: self.issueTitleWidth },
+            { text: chalk.gray(item.description), padding: PAD_TOP0_LEFT2 }
+          );
+        });
+      });
+    });
+    self.ui.div();
+    return { toString: self.ui.toString.bind(self.ui), totalIssues: totalIssues };
+  }
+}
+
+module.exports = CliReporter;

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
   },
   "homepage": "https://github.com/replicatedhq/dockerfilelint#readme",
   "dependencies": {
+    "chalk": "^1.1.1",
+    "cliui": "^3.1.0",
     "lodash": "^4.3.0",
     "yargs": "^3.32.0"
   },

--- a/test/cli_reporter.js
+++ b/test/cli_reporter.js
@@ -1,0 +1,305 @@
+'use strict';
+
+var chalk = require('chalk');
+var expect = require('chai').expect;
+var fs = require('fs');
+var CliReporter = require('../lib/cli_reporter.js');
+
+describe('cli_reporter', () => {
+  describe('#constructor(opts)', () => {
+    it('sets defaults with no options given', () => {
+      let reporter = new CliReporter();
+      expect(reporter.ui.width).to.equal(110);
+      expect(reporter.ui.wrap).to.equal(true);
+      expect(reporter.issueTitleWidth).to.equal(22);
+      expect(reporter.styles['Deprecation']).to.be.a.function;
+      expect(reporter.styles['Possible Bug']).to.be.a.function;
+      expect(reporter.styles['Clarity']).to.be.a.function;
+      expect(reporter.styles['Optimization']).to.be.a.function;
+      expect(reporter.fileReports).to.be.empty;
+    });
+
+    it('accepts width and wrap', () => {
+      let reporter = new CliReporter({ width: 200, wrap: false });
+      expect(reporter.ui.width).to.equal(200);
+      expect(reporter.ui.wrap).to.equal(false);
+      expect(reporter.issueTitleWidth).to.equal(40);
+    });
+
+    it('doesn\'t blow up when width is NaN', () => {
+      let reporter = new CliReporter({ width: 'hello' });
+      expect(reporter.ui.width).to.equal(110);
+      expect(reporter.ui.wrap).to.equal(true);
+      expect(reporter.issueTitleWidth).to.equal(22);
+    });
+  });
+
+  describe('#addFile(file, fileContent, items)', () => {
+    it('ignores an invalid file argument', () => {
+      let reporter = new CliReporter().addFile(null);
+      expect(reporter.fileReports).to.be.empty;
+    });
+
+    it('adds a good report when no items given', () => {
+      let file = './test/examples/Dockerfile.busybox';
+      let reporter = new CliReporter().addFile(file, fs.readFileSync(file, 'UTF-8'), []);
+      expect(Object.keys(reporter.fileReports)).to.have.length(1);
+      let fileReport = reporter.fileReports[file];
+      expect(fileReport.itemsByLine).to.be.empty;
+      expect(fileReport.uniqueIssues).to.equal(0);
+      expect(fileReport.contentArray).to.have.length(4);
+    });
+
+    it('modifies existing report when same file added twice', () => {
+      let file = './test/examples/Dockerfile.registry';
+      let fileContent = fs.readFileSync(file, 'UTF-8');
+      let item = {
+        title: 'Consider `--no-install-recommends`',
+        description: 'Consider using a `--no-install-recommends` when `apt-get` installing packages.  This will result in a smaller image size.  For\nmore information, see [this blog post](http://blog.replicated.com/2016/02/05/refactoring-a-dockerfile-for-image-size/)',
+        category: 'Optimization',
+        line: 5
+      };
+      let reporter = new CliReporter()
+        .addFile(file, fileContent, [])
+        .addFile(file, fileContent, [ item ]);
+      expect(Object.keys(reporter.fileReports)).to.have.length(1);
+      let fileReport = reporter.fileReports[file];
+      expect(fileReport.uniqueIssues).to.equal(1);
+      expect(fileReport.contentArray).to.have.length(16);
+      expect(fileReport.itemsByLine).to.deep.equal({
+        '5': [ item ]
+      });
+    });
+
+    it('groups multiple items by line number', () => {
+      let file = './test/examples/Dockerfile.misc';
+      let fileContent = fs.readFileSync(file, 'UTF-8');
+      let items = [
+        {
+          title: 'Base Image Missing Tag',
+          description: 'Base images should specify a tag to use.',
+          category: 'Clarity',
+          line: 5
+        },
+        {
+          title: 'First Command Must Be FROM',
+          description: 'The first instruction in a Dockerfile must specify the base image using a FROM command.  Additionally, FROM cannot appear later in a Dockerfile.',
+          category: 'Possible Bug',
+          line: 6
+        },
+        {
+          title: 'Base Image Latest Tag',
+          description: 'Base images should not use the latest tag.',
+          category: 'Clarity',
+          line: 6
+        }
+      ];
+      let reporter = new CliReporter().addFile(file, fileContent, items);
+      expect(Object.keys(reporter.fileReports)).to.have.length(1);
+      let fileReport = reporter.fileReports[file];
+      expect(fileReport.uniqueIssues).to.equal(3);
+      expect(fileReport.contentArray).to.have.length(33);
+      expect(fileReport.itemsByLine).to.deep.equal({
+        '5': [ items[0] ],
+        '6': items.splice(1)
+      });
+    });
+
+    it('ignores duplicate items', () => {
+      let file = './test/examples/Dockerfile.misc';
+      let fileContent = fs.readFileSync(file, 'UTF-8');
+      let items = [
+        {
+          title: 'First Command Must Be FROM',
+          description: 'The first instruction in a Dockerfile must specify the base image using a FROM command.  Additionally, FROM cannot appear later in a Dockerfile.',
+          category: 'Possible Bug',
+          line: 6
+        },
+        {
+          title: 'First Command Must Be FROM',
+          description: 'The first instruction in a Dockerfile must specify the base image using a FROM command.  Additionally, FROM cannot appear later in a Dockerfile.',
+          category: 'Possible Bug',
+          line: 6
+        }
+      ];
+      let reporter = new CliReporter().addFile(file, fileContent, items);
+      expect(Object.keys(reporter.fileReports)).to.have.length(1);
+      let fileReport = reporter.fileReports[file];
+      expect(fileReport.uniqueIssues).to.equal(1);
+      expect(fileReport.contentArray).to.have.length(33);
+      expect(fileReport.itemsByLine).to.deep.equal({
+        '6': [ items[0] ]
+      });
+    });
+
+    it('allows multiple files to be added', () => {
+      let file1 = './test/examples/Dockerfile.registry';
+      let file1Content = fs.readFileSync(file1, 'UTF-8');
+      let file1Items = [
+        {
+          title: 'Consider `--no-install-recommends`',
+          description: 'Consider using a `--no-install-recommends` when `apt-get` installing packages.  This will result in a smaller image size.  For\nmore information, see [this blog post](http://blog.replicated.com/2016/02/05/refactoring-a-dockerfile-for-image-size/)',
+          category: 'Optimization',
+          line: 5
+        }
+      ];
+      let file2 = './test/examples/Dockerfile.misc';
+      let file2Content = fs.readFileSync(file2, 'UTF-8');
+      let file2Items = [
+        {
+          title: 'Base Image Missing Tag',
+          description: 'Base images should specify a tag to use.',
+          category: 'Clarity',
+          line: 5
+        },
+        {
+          title: 'First Command Must Be FROM',
+          description: 'The first instruction in a Dockerfile must specify the base image using a FROM command.  Additionally, FROM cannot appear later in a Dockerfile.',
+          category: 'Possible Bug',
+          line: 6
+        }
+      ];
+      let reporter = new CliReporter()
+        .addFile(file1, file1Content, file1Items)
+        .addFile(file2, file2Content, file2Items);
+      expect(Object.keys(reporter.fileReports)).to.have.length(2);
+      let file1Report = reporter.fileReports[file1];
+      expect(file1Report.uniqueIssues).to.equal(1);
+      expect(file1Report.contentArray).to.have.length(16);
+      expect(file1Report.itemsByLine).to.deep.equal({
+        '5': file1Items
+      });
+      let file2Report = reporter.fileReports[file2];
+      expect(file2Report.uniqueIssues).to.equal(2);
+      expect(file2Report.contentArray).to.have.length(33);
+      expect(file2Report.itemsByLine).to.deep.equal({
+        '5': [ file2Items[0] ],
+        '6': [ file2Items[1] ]
+      });
+    });
+  });
+
+  describe('#buildReport()', () => {
+    it('returns blank report if no files added', () => {
+      let report = new CliReporter().buildReport();
+      expect(report.totalIssues).to.equal(0);
+      expect(report.toString()).to.equal('');
+    });
+
+    it('returns green report when one file added with no issues', () => {
+      let file = './test/examples/Dockerfile.busybox';
+      let report = new CliReporter()
+        .addFile(file, fs.readFileSync(file, 'UTF-8'), [])
+        .buildReport();
+      expect(report.totalIssues).to.equal(0);
+      expect(report.toString().split('\n')).to.deep.equal([
+        '',
+        'File:   ' + file,
+        'Issues: \u001b[32mNone found\u001b[39m 👍',
+        ''
+      ]);
+    });
+
+    it('returns green report when multiple files added with no issues', () => {
+      let file1 = './test/examples/Dockerfile.busybox';
+      let file2 = './test/examples/Dockerfile.debian';
+      let report = new CliReporter()
+        .addFile(file1, fs.readFileSync(file1, 'UTF-8'), [])
+        .addFile(file2, fs.readFileSync(file2, 'UTF-8'), [])
+        .buildReport();
+      expect(report.totalIssues).to.equal(0);
+      expect(report.toString().split('\n')).to.deep.equal([
+        '',
+        'File:   ' + file1,
+        'Issues: ' + chalk.green('None found') + ' 👍',
+        '',
+        'File:   ' + file2,
+        'Issues: ' + chalk.green('None found') + ' 👍',
+        ''
+      ]);
+    });
+
+    it('returns pretty report when file added with issues', () => {
+      let file = './test/examples/Dockerfile.misc';
+      let items = [
+        {
+          title: 'Base Image Missing Tag',
+          description: 'Base images should specify a tag to use.',
+          category: 'Clarity',
+          line: 5
+        },
+        {
+          title: 'First Command Must Be FROM',
+          description: 'The first instruction in a Dockerfile must specify the base image using a FROM command.  Additionally, FROM cannot appear later in a Dockerfile.',
+          category: 'Possible Bug',
+          line: 6
+        },
+        {
+          title: 'Base Image Latest Tag',
+          description: 'Base images should not use the latest tag.',
+          category: 'Clarity',
+          line: 6
+        },
+        {
+          title: 'Expose Only Container Port',
+          description: 'Using `EXPOSE` to specify a host port is not allowed.',
+          category: 'Deprecation',
+          line: 20
+        }
+      ];
+      let report = new CliReporter()
+        .addFile(file, fs.readFileSync(file, 'UTF-8'), items)
+        .buildReport();
+      expect(report.totalIssues).to.equal(4);
+      expect(report.toString().split('\n')).to.deep.equal([
+        '',
+        'File:   ' + file,
+        'Issues: 4',
+        '',
+        'Line 5: ' + chalk.magenta('FROM ubuntu'),
+        'Issue  Category      Title                 Description',
+        '    ' + chalk.cyan('1') + '  ' + chalk.cyan.inverse('Clarity') + '       ' + chalk.cyan('Base Image Missing') + '    ' + chalk.gray('Base images should specify a tag to use.'),
+        '                     ' + chalk.cyan('Tag'),
+        '',
+        'Line 6: ' + chalk.magenta('FROM ubuntu:latest'),
+        'Issue  Category      Title                 Description',
+        '    ' + chalk.yellow('2') + '  ' + chalk.yellow.inverse('Possible Bug') + '  ' + chalk.yellow('First Command Must') + '    ' + chalk.gray('The first instruction in a Dockerfile must specify the base image'),
+        '                     ' + chalk.yellow('Be FROM') + '               ' + chalk.gray('using a FROM command.  Additionally, FROM cannot appear later in a'),
+        '                                           ' + chalk.gray('Dockerfile.'),
+        '    ' + chalk.cyan('3') + '  ' + chalk.cyan.inverse('Clarity') + '       ' + chalk.cyan('Base Image Latest') + '     ' + chalk.gray('Base images should not use the latest tag.'),
+        '                     ' + chalk.cyan('Tag'),
+        '',
+        'Line 20: ' + chalk.magenta('EXPOSE 80:80'),
+        'Issue  Category      Title                 Description',
+        '    ' + chalk.red('4') + '  ' + chalk.red.inverse('Deprecation') + '   ' + chalk.red('Expose Only') + '           ' + chalk.gray('Using `EXPOSE` to specify a host port is not allowed.'),
+        '                     ' + chalk.red('Container Port'),
+        ''
+      ]);
+    });
+
+    it('uses Clarity style for unknown category', () => {
+      let file = './test/examples/Dockerfile.registry';
+      let fileContent = fs.readFileSync(file, 'UTF-8');
+      let item = {
+        title: 'Hello World!',
+        description: 'This is a test.',
+        category: 'Hello',
+        line: 5
+      };
+      let report = new CliReporter()
+        .addFile(file, fs.readFileSync(file, 'UTF-8'), [ item ])
+        .buildReport();
+      expect(report.totalIssues).to.equal(1);
+      expect(report.toString().split('\n')).to.deep.equal([
+        '',
+        'File:   ' + file,
+        'Issues: 1',
+        '',
+        'Line 5: ' + chalk.magenta('RUN apt-get update && \\'),
+        'Issue  Category      Title                 Description',
+        '    ' + chalk.cyan('1') + '  ' + chalk.cyan.inverse('Hello') + '         ' + chalk.cyan('Hello World!') + '          ' + chalk.gray('This is a test.'),
+        ''
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
Instead of just outputting JSON, I created a new `CliReporter` submodule that:

1. Groups `run` results into issues by line
2. Filters out duplicates
3. Builds a pretty CLI output string using [`cliui`](https://www.npmjs.com/package/cliui) and [`chalk`](https://www.npmjs.com/package/chalk)
4. Supports multiple files
5. Introduces an API contract to possibly support other types of reporters in the future

I also changed the bin exit code to be the total number of unique issues found, to better support using this tool as a CI check.

Includes tests for `CliReporter`.

Here's an example of CLI output:
![screen shot 2016-02-15 at 1 44 14 pm](https://cloud.githubusercontent.com/assets/1929625/13057628/7e82c1e6-d3eb-11e5-87e5-fe7ad2f945b9.png)

Here's an example of CLI output when there are no issues:
![screen shot 2016-02-15 at 2 39 26 pm](https://cloud.githubusercontent.com/assets/1929625/13058556/f8f15798-d3f1-11e5-9c16-acaff77cd353.png)

Note that the output width currently defaults to 110 but is easily adjustable (example of 180 width):
![screen shot 2016-02-15 at 2 37 49 pm](https://cloud.githubusercontent.com/assets/1929625/13058532/ce648e78-d3f1-11e5-8a22-42184d5028cd.png)


Also note that I played around with using [`language-docker`](https://github.com/jagregory/language-docker) and [`hl`](https://github.com/bcoe/hl) to add Dockerfile syntax highlighting when outputting the file contents for each offending line, but I didn't think the results were spectacular enough to warrant the additional dependencies.