### PR TITLE
CLI support for stdin

### DIFF
--- a/bin/dockerfilelint
+++ b/bin/dockerfilelint
@@ -7,30 +7,50 @@ var dockerfilelint = require('../lib/index');
 var CliReporter = require('../lib/cli_reporter');
 var chalk = require('chalk');
 
-if (argv._.length === 0) {
-  console.error('Usage: dockerfilelint <filename or dockerfile contents>');
-  process.exit(1);
+var fileContent;
+if (argv._.length === 0 || argv._[0] === '-') {
+  // read content from stdin
+  fileContent = '';
+
+  process.stdin.resume();
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', function (chunk) {
+    fileContent += chunk;
+  });
+  return process.stdin.on('end', function () {
+    if (fileContent.length === 0) {
+      console.error('Usage: dockerfilelint <filename or dockerfile contents>');
+      return process.exit(1);
+    }
+    processContent('<stdin>', fileContent);
+  });
 }
 
-var fileContent;
+var fileName = argv._[0];
 try {
-  var stats = fs.lstatSync(argv._[0]);
+  var stats = fs.lstatSync(fileName);
   if (stats.isFile()) {
-    fileContent = fs.readFileSync(argv._[0], 'UTF-8');
+    fileContent = fs.readFileSync(fileName, 'UTF-8');
   }
 } catch (e) {
   if (e.code === 'ENOENT') {
-    fileContent = argv._[0];
+    fileContent = fileName;
+    fileName = '<contents>';
   }
 }
 
 if (!fileContent) {
   console.error(chalk.red('Invalid input'));
+  return process.exit(1);
 }
 
-var result = dockerfilelint.run(fileContent);
-var reporter = new CliReporter();
-reporter.addFile(argv._[0], fileContent, result);
-var report = reporter.buildReport();
-console.log(report.toString());
-process.exit(report.totalIssues);
+processContent(fileName, fileContent);
+
+function processContent (name, content) {
+  var result = dockerfilelint.run(content);
+  var reporter = new CliReporter();
+  reporter.addFile(name, content, result);
+  var report = reporter.buildReport();
+  console.log(report.toString());
+  process.exit(report.totalIssues);
+}

--- a/bin/dockerfilelint
+++ b/bin/dockerfilelint
@@ -8,30 +8,29 @@ var CliReporter = require('../lib/cli_reporter');
 var chalk = require('chalk');
 
 if (argv._.length === 0) {
-  console.error('Usage: dockerfilelint <filename>');
+  console.error('Usage: dockerfilelint <filename or dockerfile contents>');
   process.exit(1);
 }
 
+var fileContent;
 try {
   var stats = fs.lstatSync(argv._[0]);
-  if (!stats.isFile()) {
-    console.error('Argument should be a file');
-    process.exit(1);
+  if (stats.isFile()) {
+    fileContent = fs.readFileSync(argv._[0], 'UTF-8');
   }
-
-  var fileContent = fs.readFileSync(argv._[0], 'UTF-8');
-  var result = dockerfilelint.run(fileContent);
-  var reporter = new CliReporter();
-  reporter.addFile(argv._[0], fileContent, result);
-  var report = reporter.buildReport();
-  console.log(report.toString());
-  process.exit(report.totalIssues);
 } catch (e) {
   if (e.code === 'ENOENT') {
-    console.error(chalk.red('File not found'));
-    process.exit(1);
+    fileContent = argv._[0];
   }
-
-  console.error(e);
-  process.exit(1);
 }
+
+if (!fileContent) {
+  console.error(chalk.red('Invalid input'));
+}
+
+var result = dockerfilelint.run(fileContent);
+var reporter = new CliReporter();
+reporter.addFile(argv._[0], fileContent, result);
+var report = reporter.buildReport();
+console.log(report.toString());
+process.exit(report.totalIssues);

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.9",
   "description": "A linter for Dockerfiles to find bugs and encourage best practices",
   "main": "./lib/index.js",
+  "bin": {
+    "dockerfilelint": "bin/dockerfilelint"
+  },
   "scripts": {
     "test": "nyc mocha",
     "coverage": "nyc report --reporter=text-lcov | coveralls"


### PR DESCRIPTION
This builds on top of PR #11 (and fixes #10) such that the CLI can now read from:

1. A file, given as file name argument (previously existing)

    ```
    dockerfilelint test/examples/Dockerfile.cli
    ```

2. Any contents given as an argument (courtesy of @marccampbell)

    ```
    dockerfilelint "FROM scratch"
    ```

3. stdin, either piped to the bin or entered when bin is executed without any arguments

    ```
    cat test/examples/Dockerfile.cli | dockerfilelint
    ```

    ```
    dockerfilelint
    FROM scratch
    ADD busybox.tar.xz /
    CMD ["sh"]
    <Ctrl-D>
    ```

This PR also allows this package to be installed globally (`npm i -g dockerfilelint`) and run as the executable bin `dockerfilelint` (can't believe I didn't notice this before).

Since this PR changes how the bin behaves when no arguments are given, it should probably constitute a semver major bump.