### PR TITLE
fix: use configFilePath when processing stdin

### DIFF
--- a/bin/dockerfilelint
+++ b/bin/dockerfilelint
@@ -25,7 +25,7 @@ if (argv._.length === 0 || argv._[0] === '-') {
       console.error('Usage: dockerfilelint <filename or dockerfile contents>');
       return process.exit(1);
     }
-    processContent('<stdin>', fileContent);
+    processContent(configFilePath, '<stdin>', fileContent);
   });
 }
 


### PR DESCRIPTION
As is, doing something like `cat Dockerfile | dockerfilelint` doesn't work because args to the `processContent()` function are off by one. Essentially it's passing `undefined` as file content, resulting in this error:

```
/Users/nexdrew/git/qi/dockerfilelint/lib/index.js:15
  var lines = content.split(/\r?\n/) || [];
                     ^

TypeError: Cannot read property 'split' of undefined
    at Object.module.exports.run (/Users/nexdrew/git/qi/dockerfilelint/lib/index.js:15:22)
    at processContent (/Users/nexdrew/git/qi/dockerfilelint/bin/dockerfilelint:56:31)
    at Socket.<anonymous> (/Users/nexdrew/git/qi/dockerfilelint/bin/dockerfilelint:28:5)
    at emitNone (events.js:85:20)
    at Socket.emit (events.js:179:7)
    at endReadableNT (_stream_readable.js:913:12)
    at _combinedTickCallback (internal/process/next_tick.js:74:11)
    at process._tickCallback (internal/process/next_tick.js:98:9)
```

Just need to pass the `configFilePath` in this scenario.

P. S. We would have caught this if we had unit tests for the CLI. I will work on putting something together to address this in the near future. 👍 