### PR TITLE
chore: add standard-version as npm run release

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "test": "nyc mocha",
-    "coverage": "nyc report --reporter=text-lcov | coveralls"
+    "coverage": "nyc report --reporter=text-lcov | coveralls",
+    "release": "standard-version"
   },
   "repository": {
     "type": "git",
@@ -38,6 +39,7 @@
     "eslint": "^1.10.3",
     "eslint-config-defaults": "^9.0.0",
     "mocha": "^2.4.5",
-    "nyc": "^5.6.0"
+    "nyc": "^5.6.0",
+    "standard-version": "^2.3.0"
   }
 }


### PR DESCRIPTION
Assuming we use [Angular commit message conventions](https://github.com/bcoe/conventional-changelog-standard/blob/master/convention.md) (which is basically just prepending `fix: ` or `feat: `) when [squashing and merging PRs into master](https://github.com/blog/2141-squash-your-commits), we can now easily tag new releases just by running [`npm run release`](https://github.com/conventional-changelog/standard-version).

This will take care of bumping the version in package.json (and will generate a CHANGELOG.md file as well) just from the commit history.

If everything looks good after cutting the release, you can push the tag to GitHub and publish to npm via:

```
git push --follow-tags origin master
npm publish
```

😎 