### PR TITLE
feat: support for multiple files on command line

### DIFF
--- a/bin/dockerfilelint
+++ b/bin/dockerfilelint
@@ -6,8 +6,12 @@ var os = require("os");
 var path = require('path');
 var argv = require('yargs').argv;
 var dockerfilelint = require('../lib/index');
-var CliReporter = require('../lib/cli_reporter');
 var chalk = require('chalk');
+
+// reporter could be a command line option
+// but until we have others, just use CliReporter
+var CliReporter = require('../lib/cli_reporter');
+var reporter = new CliReporter();
 
 var fileContent, configFilePath;
 if (argv._.length === 0 || argv._[0] === '-') {
@@ -26,36 +30,41 @@ if (argv._.length === 0 || argv._[0] === '-') {
       return process.exit(1);
     }
     processContent(configFilePath, '<stdin>', fileContent);
+    report();
   });
 }
 
-var fileName = argv._[0];
-try {
-  var stats = fs.lstatSync(fileName);
-  if (stats.isFile()) {
-    fileContent = fs.readFileSync(fileName, 'UTF-8');
-    var root = (os.platform == "win32") ? process.cwd().split(path.sep)[0] : "/";
-    configFilePath = path.resolve(path.dirname(fileName));
+argv._.forEach((fileName) => {
+  try {
+    var stats = fs.lstatSync(fileName);
+    if (stats.isFile()) {
+      fileContent = fs.readFileSync(fileName, 'UTF-8');
+      var root = (os.platform == "win32") ? process.cwd().split(path.sep)[0] : "/";
+      configFilePath = path.resolve(path.dirname(fileName));
+    }
+  } catch (e) {
+    if (e.code === 'ENOENT') {
+      fileContent = fileName;
+      fileName = '<contents>';
+      configFilePath = './';
+    }
   }
-} catch (e) {
-  if (e.code === 'ENOENT') {
-    fileContent = fileName;
-    fileName = '<contents>';
-    configFilePath = './';
+
+  if (!fileContent) {
+    console.error(chalk.red('Invalid input:'), fileName);
+    return process.exit(1);
   }
-}
 
-if (!fileContent) {
-  console.error(chalk.red('Invalid input'));
-  return process.exit(1);
-}
+  processContent(configFilePath, fileName, fileContent);
+});
 
-processContent(configFilePath, fileName, fileContent);
+report();
 
 function processContent (configFilePath, name, content) {
-  var result = dockerfilelint.run(configFilePath, content);
-  var reporter = new CliReporter();
-  reporter.addFile(name, content, result);
+  reporter.addFile(name, content, dockerfilelint.run(configFilePath, content));
+}
+
+function report () {
   var report = reporter.buildReport();
   console.log(report.toString());
   process.exit(report.totalIssues);


### PR DESCRIPTION
This should be a backwards-compatible change. Now, any of the following work:

#### Existing (Preserved) Use Cases

1. One file argument

    ```
    dockerfilelint Dockerfile
    ```

2. File contents given on command line

    ```
    dockerfilelint 'FROM latest'
    ```

3. File contents given via stdin

    ```
    dockerfilelint < Dockerfile
    cat Dockerfile | dockerfilelint
    ```

#### New Use Cases

4. Multiple file arguments

    ```
    dockerfilelint Dockerfile test/example/* /some/other/dir/*/Dockerfile
    ```

5. Mix and match file arguments with file contents given on command line

    ```
    dockerfilelint Dockerfile 'FROM latest' test/example/* /some/other/dir/*/Dockerfile
    ```

#### Notes

Functionality that reads from stdin has not been changed (i.e. interprets everything given as one file).

It will "fail fast" on the first invalid input found in command line args, e.g. `dockerfilelint Dockerfile empty.txt` does not output lint results from Dockerfile but rather results in `Invalid input: empty.txt` (exit code 1), as before.

The new functionality simple loops over given arguments and handles each separately; it **does not** expand glob arguments; glob expansion is left to the running shell.

#### Notes on Config

This PR does not attempt to change where dockerfilelint looks for config files; it still only looks for a `.dockerfilelintrc` file in the directory containing a file argument (may be different per argument) or in the cwd for "file contents as argument" or "file contents via stdin".

A couple options we might want to consider:

1. Define a series of paths to look for config files, starting at the "deepest" file argument path and moving upward to the "shallowest" file argument
2. Add a `-c`, `--config` command line option to allow the config file path to be specified by the user
3. Some combination of 1 and 2, possibly including the user's home directory as well (`~/.dockerfilelintrc`)

I figured it was prudent to get feedback on those ideas before I attempted to implement something.