### PR TITLE
README: Fix name of docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ apt-get_missing_rm
 #### From a Docker container
 (Replace the ``pwd``/Dockerfile with the path to your local Dockerfile)
 ```shell
-sudo docker run -v `pwd`/Dockerfile:/Dockerfile dockerfilelint /Dockerfile
+sudo docker run -v `pwd`/Dockerfile:/Dockerfile replicated/dockerfilelint /Dockerfile
 ```
 
 #### Online


### PR DESCRIPTION
Hello, 

I think name of docker image should be `replicated/dockerfilelint` instead of `dockerfilelint`.

Thanks
Peter

