### PR TITLE
Add version cli option to the linter

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+
+indent_style = space
+indent_size = 2
+
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -19,10 +19,11 @@ Start unit tests with `npm test`, `yarn run test`, or `docker-compose -f docker-
 Usage: dockerfilelint [files | content..] [options]
 
 Options:
-  -o, --output  Specify the format to use for output of linting results. Valid values
-                are `json` or `cli` (default).                               [string]
-  -j, --json    Output linting results as JSON, equivalent to `-o json`.    [boolean]
-  -h, --help    Show help                                                   [boolean]
+  -o, --output   Specify the format to use for output of linting results. Valid
+                 values are `json` or `cli` (default).                       [string]
+  -j, --json     Output linting results as JSON, equivalent to `-o json`.   [boolean]
+  -v, --version  Show version number                                        [boolean]
+  -h, --help     Show help                                                  [boolean]
 
 Examples:
   dockerfilelint Dockerfile         Lint a Dockerfile in the current working

--- a/bin/dockerfilelint
+++ b/bin/dockerfilelint
@@ -17,6 +17,9 @@ var argv = require('yargs')
     desc: 'Output linting results as JSON, equivalent to `-o json`.',
     type: 'boolean'
   })
+  .alias('v', 'version')
+  .version(function() { return require('../package').version; })
+  .describe('v', 'show version information')
   .help().alias('h', 'help')
   .example('dockerfilelint Dockerfile', 'Lint a Dockerfile in the current working directory\n')
   .example('dockerfilelint test/example/* -j', 'Lint all files in the test/example directory and output results in JSON\n')


### PR DESCRIPTION
Resolves #80

* Add command line option to the linter to display the version declared in the `package.json`.
* Also added `.editorconfig` to allow for consistent code style with the rest of the code base.

**Additional Question:**
I used NPM 5.3.0 which now generates a `package-lock.json` and suggests you should commit it to the repo. I have not as of yet, but can do if you like.

**Testing**
* All existing tests pass
* Tested locally by running the following commands:
`node ./bin/dockerfilelint -v` : Shows the version in `package.json`
`node ./bin/dockerfilelint -version` : Shows the version in `package.json`
`node ./bin/dockerfilelint --help` : Shows help with the new version cli option included (see below)
```shell
Usage: dockerfilelint [files | content..] [options]

Options:
  -o, --output   Specify the format to use for output of linting results. Valid
                 values are `json` or `cli` (default).                       [string]
  -j, --json     Output linting results as JSON, equivalent to `-o json`.   [boolean]
  -v, --version  Show version number                                        [boolean]
  -h, --help     Show help                                                  [boolean]

Examples:
  dockerfilelint Dockerfile         Lint a Dockerfile in the current working
                                    directory

  dockerfilelint test/example/* -j  Lint all files in the test/example directory and
                                    output results in JSON

  dockerfilelint 'FROM latest'      Lint the contents given as a string on the
                                    command line

  dockerfilelint < Dockerfile       Lint the contents of Dockerfile via stdin
```