### PR TITLE
fix: port/protocol is a valid Dockerfile syntax

### DIFF
--- a/lib/checks.js
+++ b/lib/checks.js
@@ -14,7 +14,7 @@ var commands = module.exports = {
   },
 
   expose_port_valid: function(port) {
-    return /^[0-9]+$/.test(port);
+    return /^([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])(\/tcp|\/udp){0,1}$/.test(port);
   },
 
   label_format: function(args) {

--- a/test/checks.js
+++ b/test/checks.js
@@ -16,6 +16,10 @@ describe("checks", function(){
       expect(checks.expose_port_valid("8000")).to.equal(true);
       expect(checks.expose_port_valid("abc")).to.equal(false);
       expect(checks.expose_port_valid("8000:tcp")).to.equal(false);
+      expect(checks.expose_port_valid("99999999")).to.equal(false);
+      expect(checks.expose_port_valid("80/tcp")).to.equal(true);
+      expect(checks.expose_port_valid("3000/udp")).to.equal(true);
+      expect(checks.expose_port_valid("5000/rdp")).to.equal(false);
     });
   });
 


### PR DESCRIPTION
Add support for current and correct `EXPOSE` syntax. This fixes the request in #78. 