### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,7 @@
-FROM node:7.4.0
+FROM node:10.3.0-alpine
+LABEL maintainer="Marc Campbell <marc.e.campbell@gmail.com>"
 
-MAINTAINER Marc Campbell <marc.e.campbell@gmail.com>
-
-RUN apt-get update && apt-get install --no-install-recommends -y apt-transport-https && \
-    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-    apt-get update && apt-get install --no-install-recommends -y yarn && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk --no-cache add yarn
 
 COPY ./package.json /dockerfilelint/package.json
 COPY ./lib /dockerfilelint/lib


### PR DESCRIPTION
- Use smaller Alpine base image
- Image goes from 759MB to 218MB, just under 3.5 times smaller
- Update Dockerfile to comply with lint issues