### PR TITLE
Add type definition

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,9 @@
+export interface DiagnoticItem {
+  title: string;
+  description: string;
+  category?: string;
+  line: number;
+  rule: string;
+}
+
+export function run(configPath: string, content: string): DiagnoticItem[];

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.5.0",
   "description": "A linter for Dockerfiles to find bugs and encourage best practices",
   "main": "./lib/index.js",
+  "types": "./lib/index.d.ts",
   "bin": {
     "dockerfilelint": "bin/dockerfilelint"
   },


### PR DESCRIPTION
When writing the vscode extension, I created a type definition for `dockerfilelint`. This will be helpful for someone who want to use dockerfilelint as a library with typescript.

And just a thought, if api could be something like:

```typescript
interface Options {
   // options
}

function run(opt: Options, content: string): Diagnostic[]
```

Maybe it will be better to use as a library.