### PR TITLE
Add check for 'HEALTHCHECK' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ rules:
   uppercase_commands: off
 ```
 
-The keys for the rules can be any file in the /lib/reference.js file.  At this time, it's only possible to disable rules.  They are all enabled by default.  
+The keys for the rules can be any file in the /lib/reference.js file.  At this time, it's only possible to disable rules.  They are all enabled by default.
 
-The following rules are supported:  
+The following rules are supported:
 ```
 required_params
 uppercase_commands
@@ -163,6 +163,10 @@ If you don't want to install this locally you can try it out on  [https://fromla
 ### `STOPSIGNAL`
 - [ ] Validate input
 - [ ] Only present one time
+
+### `HEALTHCHECK`
+- [x] No additional parameters when only parameter is `NONE`
+- [x] Options before `CMD` are valid
 
 ### Misc
 - [x] Only valid Dockerfile commands are present

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ If you don't want to install this locally you can try it out on  [https://fromla
 ### `HEALTHCHECK`
 - [x] No additional parameters when only parameter is `NONE`
 - [x] Options before `CMD` are valid
+- [x] Options before `CMD` have additional arguments
 
 ### Misc
 - [x] Only valid Dockerfile commands are present

--- a/lib/checks.js
+++ b/lib/checks.js
@@ -160,5 +160,31 @@ var commands = module.exports = {
       return ['invalid_format'];
     }
     return [];
+  },
+
+  is_valid_healthcheck: function (args) {
+    // if the first argument is 'NONE", there shouldnt be any more arguments
+    var words = parser.words(args);
+    if (words[0] === "none") {
+      if (words.length === 1) {
+        return [];
+      }
+      return ['invalid_format'];
+    }
+
+    // check for allowed options in 'HEALTHCHECK [options] CMD'
+    // extract only HEALTHCHECK options before CMD
+    // (as CMD in itself can have options)
+    var allowedoptions = ["--interval",
+      "--timeout",
+      "--start-period",
+      "--retries"];
+    var cmd = /\ [^-].*/.exec(args);
+    if (cmd != null) {
+      var options = args.substring(0, cmd.index).match(/--\w+/g);
+      return options.reduce((valid, item) => valid &&
+        (allowedoptions.indexOf(item) > -1), true) ? [] : ['invalid_format'];
+    }
+    return [];
   }
 }

--- a/lib/checks.js
+++ b/lib/checks.js
@@ -182,8 +182,14 @@ var commands = module.exports = {
     var cmd = /\ [^-].*/.exec(args);
     if (cmd != null) {
       var options = args.substring(0, cmd.index).match(/--\w+/g);
-      return options.reduce((valid, item) => valid &&
-        (allowedoptions.indexOf(item) > -1), true) ? [] : ['invalid_format'];
+      if (!options.reduce((valid, item) => valid &&
+        (allowedoptions.indexOf(item) > -1), true)) return ['invalid_format'];
+
+      if (options != null) {
+        var optparams = args.substring(0, cmd.index).match(/--\w+=\d+\w*/g);
+        return ((optparams != null) &&  (optparams.length == options.length)) ?
+          [] : ['healthcheck_options_missing_args'];
+      }
     }
     return [];
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -270,6 +270,11 @@ function runLine(state, instructions, idx) {
           items.push(messages.build(state.rules, item, line));
         });
         break;
+      case 'healthcheck':
+        checks.is_valid_healthcheck(args).forEach(function(item) {
+          items.push(messages.build(state.rules, item, line));
+        });
+        break;
       default:
          items.push(messages.build(state.rules, 'invalid_command', line));
          break;

--- a/lib/reference.js
+++ b/lib/reference.js
@@ -168,5 +168,10 @@ container create/start process manage the mapping to host ports using either of 
       'title': 'apt-get update with matching cache rm',
       'description': 'Use of apt-get update should be paired with rm -rf /var/lib/apt/lists/* in the same layer.',
       'category': 'Optimization'
+  },
+  'healthcheck_options_missing_args': {
+      'title': 'Missing Argument for HEALTHCHECK option',
+      'description': 'HEALTHCHECK options (like \'--timeout\') must have extra arguments (e.g. `\--timeout=30s\') ',
+      'category': 'Possible Bug'
   }
 }

--- a/test/checks.js
+++ b/test/checks.js
@@ -131,6 +131,8 @@ describe("checks", function(){
       expect(checks.is_valid_healthcheck("--invalid=10s cmd")).to.eql(['invalid_format']);
       expect(checks.is_valid_healthcheck("--interval=10s cmd")).to.be.empty;
       expect(checks.is_valid_healthcheck("--interval=10s cmd argument --someotherargument")).to.be.empty;
+      expect(checks.is_valid_healthcheck("--interval cmd argument")).to.eql(['healthcheck_options_missing_args']);
+      expect(checks.is_valid_healthcheck("--interval=10s --timeout cmd argument")).to.eql(['healthcheck_options_missing_args']);
     })
   });
 });

--- a/test/checks.js
+++ b/test/checks.js
@@ -123,4 +123,14 @@ describe("checks", function(){
       expect(checks.is_valid_env("test=test test2=test2")).to.be.empty;
     })
   });
+
+  describe("#is_valid_healthcheck(args)", function () {
+    it("validates healthcheck command is valid", function(){
+      expect(checks.is_valid_healthcheck("none")).to.be.empty;
+      expect(checks.is_valid_healthcheck("none invalidargument")).to.eql(['invalid_format']);
+      expect(checks.is_valid_healthcheck("--invalid=10s cmd")).to.eql(['invalid_format']);
+      expect(checks.is_valid_healthcheck("--interval=10s cmd")).to.be.empty;
+      expect(checks.is_valid_healthcheck("--interval=10s cmd argument --someotherargument")).to.be.empty;
+    })
+  });
 });


### PR DESCRIPTION
This PR adds support for the HEALTHCHECK command. It adds the following checks:

- allow `HEALTHCHECK` as valid Dockerfile command
- check that `HEALTHCHECK NONE` doesn't have any additional arguments
- check that the options for `HEALTHCHECK [options] CMD` are allowed according to the docs