### PR TITLE
fix yargs version argument (changed in yargs 10x)

### DIFF
--- a/bin/dockerfilelint
+++ b/bin/dockerfilelint
@@ -18,7 +18,6 @@ var argv = require('yargs')
     type: 'boolean'
   })
   .alias('v', 'version')
-  .version(() => require('../package.json').version)
   .help().alias('h', 'help')
   .example('dockerfilelint Dockerfile', 'Lint a Dockerfile in the current working directory\n')
   .example('dockerfilelint test/example/* -j', 'Lint all files in the test/example directory and output results in JSON\n')


### PR DESCRIPTION
PR #112 bumped yargs from 6x to 13x. In yargs 10x was a [breaking change](https://github.com/yargs/yargs/commit/1ef44e03ef1a2779f92bd979984a6bab3a671ee9#diff-0f426376b964e609c5c4618eb8bed3b2L1264) for the `--version` arg. By default it now looks in the `package.json`, so the `.version()` is no longer needed.

fixes #115 
