### PR TITLE
Fix #28 Add support for HEALTHCHECK command

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -156,6 +156,7 @@ function runLine(state, instructions, idx) {
         });
         break;
       case 'run':
+      case 'healthcheck':
         var aptgetSubcommands = [];
         var commands = command_parser.split_commands(args);
 


### PR DESCRIPTION
Fix #28 Add support for HEALTHCHECK command
- Reuse 'run' analyse for 'healthcheck' word too