### PR TITLE
Add a config option to process all Dockerfiles with the same configuration file

### DIFF
--- a/bin/dockerfilelint
+++ b/bin/dockerfilelint
@@ -17,8 +17,12 @@ var argv = require('yargs')
     desc: 'Output linting results as JSON, equivalent to `-o json`.',
     type: 'boolean'
   })
+  .option('c', {
+    alias: 'config',
+    desc: 'Path for .dockerfilelintrc configuration file',
+    type: 'string'
+  })
   .alias('v', 'version')
-  .version(() => require('../package.json').version)
   .help().alias('h', 'help')
   .example('dockerfilelint Dockerfile', 'Lint a Dockerfile in the current working directory\n')
   .example('dockerfilelint test/example/* -j', 'Lint all files in the test/example directory and output results in JSON\n')
@@ -64,7 +68,7 @@ argv._.forEach((fileName) => {
     if (stats.isFile()) {
       fileContent = fs.readFileSync(fileName, 'UTF-8');
       var root = (os.platform == "win32") ? process.cwd().split(path.sep)[0] : "/";
-      configFilePath = path.resolve(path.dirname(fileName));
+      configFilePath = argv.config || path.resolve(path.dirname(fileName));
     }
   } catch (e) {
     if (e.code === 'ENOENT') {


### PR DESCRIPTION
This add a configuration option so you can pass in the path to your configuration file and have it use the same config against all of the Dockerfile(s) the linter has found, before it looked for the `.dockerfilelintrc` next to the Dockerfile and if not found used its defaults.

This option needs to be used with the path for the file not directly to the file. This is because https://github.com/replicatedhq/dockerfilelint/blob/master/lib/index.js#L85 adds the `.dockerfilelintrc` automatically.  I'm happy to work on this further to allow you to pass the full path+filename if wanted.

Here's the output showing this is working with both the short/long hand argument.

```
bash-5.0# cat /.dockerfilelintrc 
rules:
  uppercase_commands: off
```

Default (no `.dockerfilelintrc` located next to Dockerfile)

```
bash-5.0# node_modules/dockerfilelint/bin/dockerfilelint /tmp/Dockerfile

File:   /tmp/Dockerfile
Issues: 3

Line 4: FROM ubuntu:latest
Issue  Category      Title                 Description
    1  Clarity       Base Image Latest     Base images should not use the latest tag.
                     Tag

Line 5: RUN apt-get update && \
Issue  Category      Title                 Description
    2  Optimization  Consider              Consider using a `--no-install-recommends` when `apt-get`
                     `--no-install-recomm  installing packages.  This will result in a smaller image size.
                     ends`                 For
                                           more information, see [this blog
                                           post](http://blog.replicated.com/2016/02/05/refactoring-a-dockerfil
                                           e-for-image-size/)

Line 10: copy . /usr/src/hello
Issue  Category      Title                 Description
    3  Clarity       Capitalize            For clarity and readability, all instructions in a Dockerfile
                     Dockerfile            should be uppercase.
                     Instructions          This is a convention adopted by most of the official images and
                                           greatly improves readability in long Dockerfiles.  For an example
                                           of
                                           why this makes a difference, check out the current [redis
                                           Dockerfile](https://github.com/docker-library/redis/blob/b375650fb6
                                           9b7db819e90c0033433c705b28656e/3.0/Dockerfile)
                                           and you should be able to easily see the instructions used.
```

Short and longhand flags with specified `.dockerfilelintrc `

```
bash-5.0# node_modules/dockerfilelint/bin/dockerfilelint /tmp/Dockerfile -c /

File:   /tmp/Dockerfile
Issues: 2

Line 4: FROM ubuntu:latest
Issue  Category      Title                 Description
    1  Clarity       Base Image Latest     Base images should not use the latest tag.
                     Tag

Line 5: RUN apt-get update && \
Issue  Category      Title                 Description
    2  Optimization  Consider              Consider using a `--no-install-recommends` when `apt-get`
                     `--no-install-recomm  installing packages.  This will result in a smaller image size.
                     ends`                 For
                                           more information, see [this blog
                                           post](http://blog.replicated.com/2016/02/05/refactoring-a-dockerfil
                                           e-for-image-size/)

bash-5.0# node_modules/dockerfilelint/bin/dockerfilelint /tmp/Dockerfile --config /

File:   /tmp/Dockerfile
Issues: 2

Line 4: FROM ubuntu:latest
Issue  Category      Title                 Description
    1  Clarity       Base Image Latest     Base images should not use the latest tag.
                     Tag

Line 5: RUN apt-get update && \
Issue  Category      Title                 Description
    2  Optimization  Consider              Consider using a `--no-install-recommends` when `apt-get`
                     `--no-install-recomm  installing packages.  This will result in a smaller image size.
                     ends`                 For
                                           more information, see [this blog
                                           post](http://blog.replicated.com/2016/02/05/refactoring-a-dockerfil
                                           e-for-image-size/)

bash-5.0# 
```

I also included the fix from #119 since it seems like that is gonna get merged and it helped clean up the output avoiding that error. (Happy to remove that also if wanted, to keep the history clean)

