### PR TITLE
Add Gitpod to simplify contributor onloading

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,2 @@
+tasks:
+  - init: yarn install && yarn run test

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Coverage Status](https://coveralls.io/repos/github/replicatedhq/dockerfilelint/badge.svg?branch=master)](https://coveralls.io/github/replicatedhq/dockerfilelint?branch=master)
 [![Build Status](https://travis-ci.org/replicatedhq/dockerfilelint.svg?branch=master)](https://travis-ci.org/replicatedhq/dockerfilelint)
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/replicatedhq/dockerfilelint) 
+
 
 `Dockerfilelint` is an node module that analyzes a Dockerfile and looks for common traps, mistakes and helps enforce best practices:
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/50386709/73626227-cf05bb80-460d-11ea-83b8-029744603af2.png)
This PR adds a Gitpod setup to the repository this will allow contributors to contribute with the push of a button with the project already build, all from within a browser

Try It Out
https://gitpod.io/#https://github.com/JesterOrNot/dockerfilelint