### PR TITLE
chore: move base image to latest node lts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.3.0-alpine
+FROM node:12.18-alpine
 LABEL maintainer="Marc Campbell <marc.e.campbell@gmail.com>"
 
 RUN apk --no-cache add yarn


### PR DESCRIPTION
node 10 is only in maintenance mode until April so it makes sense to move to 12, the active LTS version with support until April 2022.