### PR TITLE
Fix handling of --start-period option for HEALTHCHECK

### DIFF
--- a/lib/checks.js
+++ b/lib/checks.js
@@ -190,12 +190,12 @@ var commands = module.exports = {
       "--retries"];
     var cmd = /\ [^-].*/.exec(args);
     if (cmd != null) {
-      var options = args.substring(0, cmd.index).match(/--\w+/g);
+      var options = args.substring(0, cmd.index).match(/--[\w-]+/g);
       if (!options.reduce((valid, item) => valid &&
         (allowedoptions.indexOf(item) > -1), true)) return ['invalid_format'];
 
       if (options != null) {
-        var optparams = args.substring(0, cmd.index).match(/--\w+=\d+\w*/g);
+        var optparams = args.substring(0, cmd.index).match(/--[\w-]+=\d+\w*/g);
         return ((optparams != null) &&  (optparams.length == options.length)) ?
           [] : ['healthcheck_options_missing_args'];
       }

--- a/test/checks.js
+++ b/test/checks.js
@@ -133,6 +133,7 @@ describe("checks", function(){
       expect(checks.is_valid_healthcheck("--interval=10s cmd argument --someotherargument")).to.be.empty;
       expect(checks.is_valid_healthcheck("--interval cmd argument")).to.eql(['healthcheck_options_missing_args']);
       expect(checks.is_valid_healthcheck("--interval=10s --timeout cmd argument")).to.eql(['healthcheck_options_missing_args']);
+      expect(checks.is_valid_healthcheck("--interval=30s --timeout=10s --start-period=15s --retries=5 cmd")).to.be.empty;
     })
   });
 });


### PR DESCRIPTION
As adressed in #166 is_valid_healthcheck() throws an error when the '--start-period' option is provided.
This is due a broken regexp that doesn't  handle the dash in the option name.
This PR fixes this.