### PR TITLE
Fix JSON parsing in is_valid_shell() when input is no JSON

### DIFF
--- a/lib/checks.js
+++ b/lib/checks.js
@@ -163,9 +163,15 @@ var commands = module.exports = {
   },
 
   is_valid_shell: function(args) {
-    // Dockerfile syntax requires that args be in JSON array format
-    var parsed = JSON.parse(args);
-    if (parsed.constructor !== Array) {
+    var parsed = null;
+
+    try {
+      // Dockerfile syntax requires that args be in JSON array format
+      parsed = JSON.parse(args);
+    }
+    catch (e) {}
+
+    if (parsed === null || parsed.constructor !== Array) {
       return ['invalid_format'];
     }
     return [];

--- a/test/checks.js
+++ b/test/checks.js
@@ -135,4 +135,11 @@ describe("checks", function(){
       expect(checks.is_valid_healthcheck("--interval=10s --timeout cmd argument")).to.eql(['healthcheck_options_missing_args']);
     })
   });
+
+  describe("#is_valid_shell(args)", function() {
+    it("validates shell command is valid", function(){
+      expect(checks.is_valid_shell("cmd1 --arg1=10s arg2")).to.eql(['invalid_format']);
+      expect(checks.is_valid_shell("[\"cmd1\", \"cmd2\"]")).to.be.empty;
+    })
+  });
 });


### PR DESCRIPTION
`is_valid_shell()` breaks when you provide an input that is not proper JSON.

    SyntaxError: Unexpected number in JSON at position 1
        at JSON.parse (<anonymous>)

This PR adds a try/catch to prevent that.
It also adds the unit tests for `is_valid_shell()` that were missing.