### PR TITLE
Issue 173: Added ability to provide Custom Rulesets

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,43 @@ apt-get_missing_rm
 deprecated_in_1.13
 ```
 
+### Custom Rulesets
+
+You can add your own custom rulesets by supplying the -r option to dockerfilelint. Simply create a ruleset.js file first. It must export the "rules" variable with the proper keys. Here is an example of a simple two-rule ruleset file.
+
+```
+module.exports.rules = {
+  'add_prohibited': {
+    'title': 'ADD Command Prohibited',
+    'description': 'ADD command is not allowed! Use copy instead!',
+    'category': 'Optimization',
+    'function': ({ messages, state, cmd, args, line, instruction }) => {
+      if(cmd.toLowerCase() === 'add'){
+        return messages.build(state.rules, 'add_prohibited', line);
+      }
+    }
+  },
+
+  'avoid_curl_bashing': {
+    'title': 'Avoid Curl Bashing',
+    'description': 'Do not pipe bash or wget commands directly to shell. This is very insecure and can cause many issues with security. If you must, make sure to vet the script and verify its authenticity. E.G. "RUN wget http://my_website/script.sh | sh" is prohibited',
+    'category': 'Optimization',
+    'function': ({ messages, state, cmd, line, args}) => {
+      // This function doesn't care about full instruction so it omits if from arguments
+      if(cmd.toLowerCase() === 'run' && args.match(/(curl|wget)[^|^>]*[|>]/)){
+        return messages.build(state.rules, 'avoid_curl_bashing', line);
+      }
+    }
+  },
+}
+```
+
+Then simply call dockerfilelint with the -r command to pass the ruleset file in:
+
+```
+dockerfilelint -r path/to/ruleset.js path/to/Dockerfile
+```
+
 #### From a Docker container
 
 (Replace the ``pwd``/Dockerfile with the path to your local Dockerfile)

--- a/README.md
+++ b/README.md
@@ -33,20 +33,26 @@ Options:
   -o, --output   Specify the format to use for output of linting results. Valid values
                  are `json` or `cli` (default).                               [string]
   -j, --json     Output linting results as JSON, equivalent to `-o json`.    [boolean]
+  -c, --config   Path for .dockerfilelintrc configuration file                [string]
+  -r, --ruleset  Path for custom ruleset js file                              [string]
   -v, --version  Show version number                                         [boolean]
   -h, --help     Show help                                                   [boolean]
 
 Examples:
-  dockerfilelint Dockerfile         Lint a Dockerfile in the current working
-                                    directory
+  dockerfilelint Dockerfile                    Lint a Dockerfile in the current
+                                               working directory
 
-  dockerfilelint test/example/* -j  Lint all files in the test/example directory and
-                                    output results in JSON
+  dockerfilelint test/example/* -j             Lint all files in the test/example
+                                               directory and output results in JSON
 
-  dockerfilelint 'FROM latest'      Lint the contents given as a string on the
-                                    command line
+  dockerfilelint 'FROM latest'                 Lint the contents given as a string on
+                                               the command line
 
-  dockerfilelint < Dockerfile       Lint the contents of Dockerfile via stdin
+  dockerfilelint < Dockerfile                  Lint the contents of Dockerfile via
+                                               stdin
+  dockerfilelint -r custom-ruleset.js          Lint the contents of Dockerfile using
+  Dockerfile                                   the default rules plus a set of custom
+                                               rules defined in custom-ruleset.js
 ```
 
 #### Configuring

--- a/README.md
+++ b/README.md
@@ -99,10 +99,8 @@ module.exports.rules = {
     'title': 'ADD Command Prohibited',
     'description': 'ADD command is not allowed! Use copy instead!',
     'category': 'Optimization',
-    'function': ({ messages, state, cmd, args, line, instruction }) => {
-      if(cmd.toLowerCase() === 'add'){
-        return messages.build(state.rules, 'add_prohibited', line);
-      }
+    'function': ({ cmd, args, line, instruction }) => {
+      return cmd.toLowerCase() === 'add';
     }
   },
 
@@ -110,17 +108,17 @@ module.exports.rules = {
     'title': 'Avoid Curl Bashing',
     'description': 'Do not pipe bash or wget commands directly to shell. This is very insecure and can cause many issues with security. If you must, make sure to vet the script and verify its authenticity. E.G. "RUN wget http://my_website/script.sh | sh" is prohibited',
     'category': 'Optimization',
-    'function': ({ messages, state, cmd, line, args}) => {
+    'function': ({ cmd, line, args}) => {
       // This function doesn't care about full instruction so it omits if from arguments
-      if(cmd.toLowerCase() === 'run' && args.match(/(curl|wget)[^|^>]*[|>]/)){
-        return messages.build(state.rules, 'avoid_curl_bashing', line);
-      }
+      return cmd.toLowerCase() === 'run' && args.match(/(curl|wget)[^|^>]*[|>]/);
     }
   },
 }
 ```
 
-Then simply call dockerfilelint with the -r command to pass the ruleset file in:
+Notice, if a rule function return true, it will be sent as a message to the reporter, otherwise it will be ignored for that line.
+
+After you have your ruleset defined, simply call dockerfilelint with the -r command to pass the ruleset file in:
 
 ```
 dockerfilelint -r path/to/ruleset.js path/to/Dockerfile

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ module.exports.rules = {
 }
 ```
 
-Notice, if a rule function return true, it will be sent as a message to the reporter, otherwise it will be ignored for that line.
+Notice, if a rule function returns true, it will be sent as a message to the reporter, otherwise it will be ignored for that line.
 
 After you have your ruleset defined, simply call dockerfilelint with the -r command to pass the ruleset file in:
 

--- a/bin/dockerfilelint
+++ b/bin/dockerfilelint
@@ -22,12 +22,18 @@ var argv = require('yargs')
     desc: 'Path for .dockerfilelintrc configuration file',
     type: 'string'
   })
+  .option('r', {
+    alias: 'ruleset',
+    desc: 'Path for custom ruleset js file',
+    type: 'string'
+  })
   .alias('v', 'version')
   .help().alias('h', 'help')
   .example('dockerfilelint Dockerfile', 'Lint a Dockerfile in the current working directory\n')
   .example('dockerfilelint test/example/* -j', 'Lint all files in the test/example directory and output results in JSON\n')
   .example(`dockerfilelint 'FROM latest'`, 'Lint the contents given as a string on the command line\n')
   .example('dockerfilelint < Dockerfile', 'Lint the contents of Dockerfile via stdin')
+  .example('dockerfilelint -c custom-ruleset.js Dockerfile', 'Lint the contents of Dockerfile using the default rules plus a set of custom rules defined in custom-ruleset.js')
   .wrap(86)
   .check(argv => {
     if (!argv.output && argv.json) argv.output = 'json'
@@ -41,7 +47,7 @@ var chalk = require('chalk');
 var Reporter = argv.output === 'json' ? require('../lib/reporter/json_reporter') : require('../lib/reporter/cli_reporter');
 var reporter = new Reporter();
 
-var fileContent, configFilePath;
+var fileContent, configFilePath, customRuleset;
 if (argv._.length === 0 || argv._[0] === '-') {
   // read content from stdin
   fileContent = '';
@@ -83,13 +89,14 @@ argv._.forEach((fileName) => {
     return process.exit(1);
   }
 
-  processContent(configFilePath, fileName, fileContent);
+  processContent(configFilePath, fileName, fileContent, argv.ruleset);
 });
 
 report();
 
-function processContent (configFilePath, name, content) {
-  reporter.addFile(name, content, dockerfilelint.run(configFilePath, content));
+function processContent (configFilePath, name, content, customRulesetPath) {
+  const items = dockerfilelint.run(configFilePath, content, customRulesetPath);
+  reporter.addFile(name, content, items, customRulesetPath);
 }
 
 function report () {

--- a/bin/dockerfilelint
+++ b/bin/dockerfilelint
@@ -33,7 +33,7 @@ var argv = require('yargs')
   .example('dockerfilelint test/example/* -j', 'Lint all files in the test/example directory and output results in JSON\n')
   .example(`dockerfilelint 'FROM latest'`, 'Lint the contents given as a string on the command line\n')
   .example('dockerfilelint < Dockerfile', 'Lint the contents of Dockerfile via stdin')
-  .example('dockerfilelint -c custom-ruleset.js Dockerfile', 'Lint the contents of Dockerfile using the default rules plus a set of custom rules defined in custom-ruleset.js')
+  .example('dockerfilelint -r custom-ruleset.js Dockerfile', 'Lint the contents of Dockerfile using the default rules plus a set of custom rules defined in custom-ruleset.js')
   .wrap(86)
   .check(argv => {
     if (!argv.output && argv.json) argv.output = 'json'

--- a/lib/index.js
+++ b/lib/index.js
@@ -310,19 +310,18 @@ function runLine(state, instructions, idx) {
 
   if (state.customRuleset){
     // For each custom rule, run the rule and push the result
-    for(const rule of Object.values(state.customRuleset)){
-      // Rules are responsible for pushing to the message bus, thus send it here as an argument
+    for(const rule of Object.entries(state.customRuleset)){
+      // Rules simply should return true or false. This can also be interpreted as 
+      // truthy or falsey. If true, send the message to the message bus.
       // pass as a dictionary to allow users to only use the arguments that they want
-      const result = rule.function?.({ 
-        messages: messages,
-        state: state, 
+      const result = rule[1].function?.({
         cmd: cmd, 
         args: args, 
         line: line, 
         instruction: instruction
       });
       if (result) {
-        items.push(result);
+        items.push(messages.build(state.rules, rule[0], line));
       }
     }
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,7 @@ var apk = require('./apk');
 var apt = require('./apt');
 var messages = require('./messages');
 
-module.exports.run = function(configPath, content) {
+module.exports.run = function(configPath, content, customRulesetPath) {
   // Parse the file into an array of instructions
   var instructions = {};
   var lines = content.split(/\r?\n/) || [];
@@ -56,8 +56,12 @@ module.exports.run = function(configPath, content) {
       cmdFound: false // this doesn't seem to be used anywhere
     }],
     items: [],
-    rules: loadRules(configPath)
+    rules: loadRules(configPath),
+    customRuleset: loadCustomRuleset(customRulesetPath)
   }
+
+  // Add custom ruleset to message bus
+  messages.addCustomRuleset(state.customRuleset);
 
   for (var idx in instructions) {
     var result = runLine(state, instructions, idx);
@@ -99,6 +103,16 @@ function loadRules(configPath) {
 
   var rc = yaml.safeLoad(configFileContents);
   return rc.rules;
+}
+
+function loadCustomRuleset(customRulesetPath){
+  if (!customRulesetPath) return {};
+  try{
+    const absPath = path.join(process.cwd(), customRulesetPath)
+    return require(absPath)?.rules;
+  } catch (e) {
+    return {};
+  }
 }
 
 function tryLoadFile(filename) {
@@ -292,6 +306,25 @@ function runLine(state, instructions, idx) {
          items.push(messages.build(state.rules, 'invalid_command', line));
          break;
      }
+  }
+
+  if (state.customRuleset){
+    // For each custom rule, run the rule and push the result
+    for(const rule of Object.values(state.customRuleset)){
+      // Rules are responsible for pushing to the message bus, thus send it here as an argument
+      // pass as a dictionary to allow users to only use the arguments that they want
+      const result = rule.function?.({ 
+        messages: messages,
+        state: state, 
+        cmd: cmd, 
+        args: args, 
+        line: line, 
+        instruction: instruction
+      });
+      if (result) {
+        items.push(result);
+      }
+    }
   }
 
   // Remove any null items from the result

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -1,6 +1,10 @@
 var reference = require('./reference');
 
 var messages = module.exports = {
+  addCustomRuleset: function(customRules) {
+    reference = { ...reference, ...customRules };
+  },
+
   parseBool: function(s) {
     s = s.toLowerCase();
     if (s === 'off' || s === 'false' || s === '0' || s === 'n') {

--- a/lib/reporter/cli_reporter.js
+++ b/lib/reporter/cli_reporter.js
@@ -36,6 +36,9 @@ class CliReporter extends Reporter {
       self.ui.div(
         { text: 'File:   ' + file, padding: PAD_TOP1_LEFT0 }
       );
+      if(fileReport.customRulesetPath){
+        self.ui.div('Custom Ruleset:   ' + fileReport.customRulesetPath);
+      }
       let linesWithItems = Object.keys(fileReport.itemsByLine);
       if (linesWithItems.length === 0) {
         self.ui.div('Issues: ' + chalk.green('None found') + ' 👍');

--- a/lib/reporter/json_reporter.js
+++ b/lib/reporter/json_reporter.js
@@ -33,7 +33,12 @@ class JsonReporter extends Reporter {
       let fileReport = self.fileReports[file];
       let linesWithItems = Object.keys(fileReport.itemsByLine);
 
-      let jsonReport = { file: file, issues_count: fileReport.uniqueIssues, issues: [] };
+      let jsonReport = { 
+        file: file, 
+        issues_count: fileReport.uniqueIssues, 
+        customRuleset: fileReport.customRulesetPath, 
+        issues: []
+      };
 
       if (linesWithItems.length === 0) {
         reportFiles.push(jsonReport);

--- a/lib/reporter/reporter.js
+++ b/lib/reporter/reporter.js
@@ -8,13 +8,14 @@ class Reporter {
   }
 
   // group file items by line for easy reporting
-  addFile (file, fileContent, items) {
+  addFile (file, fileContent, items, customRulesetPath) {
     let self = this;
     if (!file) return self;
     let fileReport = self.fileReports[file] || {
       itemsByLine: {},
       uniqueIssues: 0,
-      contentArray: (fileContent || '').replace('\r', '').split('\n')
+      contentArray: (fileContent || '').replace('\r', '').split('\n'),
+      customRulesetPath: customRulesetPath
     };
     let ibl = fileReport.itemsByLine;
     [].concat(items).forEach((item) => {

--- a/test/examples/Dockerfile.custom-ruleset
+++ b/test/examples/Dockerfile.custom-ruleset
@@ -1,0 +1,3 @@
+FROM scratch
+
+RUN wget http://my_website/script.sh | sh

--- a/test/index.js
+++ b/test/index.js
@@ -160,6 +160,24 @@ describe("index", function(){
     });
   });
 
+  describe("#customRuleset", function() {
+    it("validates a custom ruleset can be supplied to extend rules", function() {
+      let expected = [{
+        title: 'Avoid Curl Bashing',
+        line: 3,
+        rule: 'avoid_curl_bashing'
+      }]
+      let result = dockerfilelint.run('./test/examples', fs.readFileSync('./test/examples/Dockerfile.custom-ruleset', 'UTF-8'), './test/ruleset.js');
+      _.forEach(result, function(r) {
+        delete r['function'];
+        delete r['description'];
+        delete r['category'];
+      });
+      expect(result).to.have.length(expected.length);
+      expect(result).to.deep.equal(expected);
+    });
+  });
+
   describe("#misc", function(){
     it("validates the misc Dockerfile have the exact right issues reported", function(){
       var expected = [

--- a/test/ruleset.js
+++ b/test/ruleset.js
@@ -3,10 +3,8 @@ module.exports.rules = {
     'title': 'ADD Command Prohibited',
     'description': 'ADD command is not allowed! Use copy instead!',
     'category': 'Optimization',
-    'function': ({ messages, state, cmd, args, line, instruction }) => {
-      if(cmd.toLowerCase() === 'add'){
-        return messages.build(state.rules, 'add_prohibited', line);
-      }
+    'function': ({ cmd, args, line, instruction }) => {
+      return cmd.toLowerCase() === 'add';
     }
   },
 
@@ -14,11 +12,9 @@ module.exports.rules = {
     'title': 'Avoid Curl Bashing',
     'description': 'Do not pipe bash or wget commands directly to shell. This is very insecure and can cause many issues with security. If you must, make sure to vet the script and verify its authenticity. E.G. "RUN wget http://my_website/script.sh | sh" is prohibited',
     'category': 'Optimization',
-    'function': ({ messages, state, cmd, line, args}) => {
+    'function': ({ cmd, line, args}) => {
       // This function doesn't care about full instruction so it omits if from arguments
-      if(cmd.toLowerCase() === 'run' && args.match(/(curl|wget)[^|^>]*[|>]/)){
-        return messages.build(state.rules, 'avoid_curl_bashing', line);
-      }
+      return cmd.toLowerCase() === 'run' && args.match(/(curl|wget)[^|^>]*[|>]/);
     }
   },
 }

--- a/test/ruleset.js
+++ b/test/ruleset.js
@@ -1,0 +1,24 @@
+module.exports.rules = {
+  'add_prohibited': {
+    'title': 'ADD Command Prohibited',
+    'description': 'ADD command is not allowed! Use copy instead!',
+    'category': 'Optimization',
+    'function': ({ messages, state, cmd, args, line, instruction }) => {
+      if(cmd.toLowerCase() === 'add'){
+        return messages.build(state.rules, 'add_prohibited', line);
+      }
+    }
+  },
+
+  'avoid_curl_bashing': {
+    'title': 'Avoid Curl Bashing',
+    'description': 'Do not pipe bash or wget commands directly to shell. This is very insecure and can cause many issues with security. If you must, make sure to vet the script and verify its authenticity. E.G. "RUN wget http://my_website/script.sh | sh" is prohibited',
+    'category': 'Optimization',
+    'function': ({ messages, state, cmd, line, args}) => {
+      // This function doesn't care about full instruction so it omits if from arguments
+      if(cmd.toLowerCase() === 'run' && args.match(/(curl|wget)[^|^>]*[|>]/)){
+        return messages.build(state.rules, 'avoid_curl_bashing', line);
+      }
+    }
+  },
+}


### PR DESCRIPTION
Custom rulesets is a standard with many linters and provides flexibility for users to create their own linting rules that may apply only to their company or project.

**What I changed**

1) Added -r (--ruleset) flag for supplying a custom ruleset js file
2) Defined the syntax of the ruleset file, which closely matches the "reference.js" file syntax with the single addition of a function key to provide the logic for the rule.
3) Added custom ruleset key into both the cli and json reporters so users can see when their custom rulesets are being used
4) Updated README file to document how users can implement this feature with an example command and example ruleset file
5) Added a mocha test for ensuring that a test custom ruleset accurately reports issues defined within it for a custom dockerfile
6) Updated help doc with new flag and with example of usage, updated README to reflect this change.

**Why I changed it**

I work for Cisco Systems that is implementing a dockerfile linter. I am using this repository in that effort and i have to patch this package to be able to supply my own custom rulesets for Cisco Standards. I am also patching this library to be able to provide a "severity" to choose whether or not certain rules cause the exit code to be non-zero. But that is something i can submit if this PR is approved.

**How I tested it**

I only needed to add a single test to verify rulesets work appropriately by adding a custom test ruleset and a custom negative test dockerfile into the examples folder. Here is the result of "npm run test"

```
  74 passing (106ms)

--------------------|----------|----------|----------|----------|-------------------|
File                |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
--------------------|----------|----------|----------|----------|-------------------|
All files           |    98.11 |    93.99 |    98.91 |    98.08 |                   |
 lib                |    97.98 |    94.26 |    98.68 |    97.95 |                   |
  apk.js            |      100 |      100 |      100 |      100 |                   |
  apt.js            |      100 |      100 |      100 |      100 |                   |
  checks.js         |       97 |    94.59 |      100 |    96.97 |        95,149,203 |
  command_parser.js |    97.96 |    90.91 |      100 |    97.96 |                85 |
  index.js          |    97.02 |    92.31 |    95.65 |    96.99 |... 24,301,302,304 |
  messages.js       |      100 |      100 |      100 |      100 |                   |
  parser.js         |      100 |    93.62 |      100 |      100 |          59,67,93 |
  reference.js      |      100 |      100 |      100 |      100 |                   |
 lib/reporter       |    98.81 |       90 |      100 |    98.78 |                   |
  cli_reporter.js   |    97.44 |       90 |      100 |    97.44 |                40 |
  json_reporter.js  |      100 |      100 |      100 |      100 |                   |
  reporter.js       |      100 |     87.5 |      100 |      100 |                17 |
--------------------|----------|----------|----------|----------|-------------------|
```

Thanks:) Let me know if you need anything.