### PR TITLE
Make dockerfilelint available in pre-commit ecosystem

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: dockerfilelint
+  name: Dockerfilelint
+  description: A linter for Dockerfiles to find bugs and encourage best practices
+  entry: dockerfilelint
+  language: node
+  types_or: [dockerfile]


### PR DESCRIPTION
## Purpose

This PR adds a `pre-commit-hooks.yaml` file, which defines the necessary meta-data for this linter to be used in the [pre-commit](https://pre-commit.com/) ecosystem.

**pre-commit** is a python based [Git Hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) manager, that aims to provide state-of-the art linters for various languages, regardless of what languages said linters are written in.

## Testing

This PR can be tested manually from any git repository via:
```sh
# currently pointing to my fork
pre-commit try-repo https://github.com/ChiefGokhlayeh/dockerfilelint
```
Provided of course, pre-commit is [installed](https://pre-commit.com/#install).

## Usage

Users who wish to lint their Dockerfiles with dockerfilelint simply create a `pre-commit-config.yaml` inside their repository, such as this one:
```yaml
repos:
  - repo: https://github.com/replicatedhq/dockerfilelint # use https://github.com/ChiefGokhlayeh/dockerfilelint for testing this PR
    rev: master # should be replaced by release tag
    hooks:
      - id: dockerfilelint

```